### PR TITLE
Updates moment to pass node security project's checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "npm": ">=1.2.10"
   },
   "dependencies": {
-    "moment": "~2.0.0"
+    "moment": "^2.2.0"
   },
   "devDependencies": {
     "coffee-script": "~1.7.1"


### PR DESCRIPTION
https://nodesecurity.io/advisories/55

Running `nsp check -o summary` will fail because moment 2.0.0 has been flagged as having a security issue. This allows a later patched version to be installed.

```
$ nsp check -o summary
(+) 1 vulnerabilities found
 Name     Installed   Patched    Path                                                              More Info
 moment   2.0.0       >=2.11.2   migration@0.3.0 > moment@2.0.0   https://nodesecurity.io/advisories/55
```
